### PR TITLE
Update README on how to add private package auth and update actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ For all app testing run the following:
 php artisan vendor:publish --provider="Marcusmyers\LaravelGithubActions\LaravelGithubActionsServiceProvider" --tag="all-app-actions"
 ```
 
+### Private Packagist Repo
+
+In order to install packages that are on a private packagist server you
+will have to add the following to workflow file. The example below uses
+Laravel Nova.
+
+```
+composer config http-basic.nova.laravel.com ${{ secrets.NOVA_USERNAME }} ${{ secrets.NOVA_PASSWORD }}
+```
+
 ### Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "laravel-github-actions"
     ],
     "homepage": "https://github.com/marcusmyers/laravel-github-actions",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "license": "MIT",
     "type": "library",
     "authors": [

--- a/github-action-files/ci-app.yml
+++ b/github-action-files/ci-app.yml
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.os }}-composer-
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
@@ -39,14 +39,10 @@ jobs:
       run: composer validate
 
     - name: Prepare Laravel Application
-      run: php -r "file_exists('.env') || copy('.env.ci', '.env');"
-
-    - name: Install composer dependencies
       run: |
-        composer install --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-
-    - name: Generate key
-      run: php artisan key:generate
+        php -r "file_exists('.env') || copy('.env.ci', '.env');"
+        composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+        php artisan key:generate
 
     - name: Create DB and schemas
       run: |

--- a/github-action-files/ci-package.yml
+++ b/github-action-files/ci-package.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install composer dependencies
       run: |
-        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" -q --no-interaction --no-update
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
     - name: Run Tests

--- a/github-action-files/dusk.yml
+++ b/github-action-files/dusk.yml
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.os }}-composer-
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
@@ -44,13 +44,10 @@ jobs:
       run: composer validate
 
     - name: Prepare Laravel Application
-      run: php -r "file_exists('.env') || copy('.env.dusk.testing', '.env');"
-
-    - name: Install composer dependencies
-      run: composer install --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist --optimize-autoloader
-
-    - name: Generate key
-      run: php artisan key:generate
+      run: |
+        php -r "file_exists('.env') || copy('.env.dusk.testing', '.env');"
+        composer install --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist --optimize-autoloader
+        php artisan key:generate
 
     - name: Create DB and schemas
       run: |


### PR DESCRIPTION
This commit updates the README to show how to add authentication for
your private packages while running test on Github Actions. This commit
also updates a couple action versions.